### PR TITLE
Use lxml parser for web scraping

### DIFF
--- a/scrape_fran_cache.py
+++ b/scrape_fran_cache.py
@@ -31,7 +31,7 @@ def fetch_franking_asx(code: str):
     resp = requests.get(url, headers=headers, timeout=15)
     resp.raise_for_status()
 
-    soup = BeautifulSoup(resp.text, "html.parser")
+    soup = BeautifulSoup(resp.text, "lxml")
     table = soup.find("table")
     if not table or not table.tbody:
         print(f"‼️  No table found for {code}")


### PR DESCRIPTION
## Summary
- Switch BeautifulSoup parser to `lxml` in `scrape_fran_cache.py`
- Confirm `lxml` dependency remains in `requirements.txt`

## Testing
- `python scrape_fran_cache.py` *(fails: HTTPSConnectionPool / ProxyError 403)*

------
https://chatgpt.com/codex/tasks/task_e_688eae9c6fd8832d89716fbf9d8bcd54